### PR TITLE
Escape mandays and due date

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -169,8 +169,8 @@ if ($_SESSION['loggedin'] ?? false) {
                 <p class="card-text mb-1">
                     <strong>Priority:</strong> <?= htmlspecialchars($task['priority']) ?><br>
                     <strong>Effort:</strong> <?= htmlspecialchars($task['effort']) ?><br>
-                    <strong>Mandays:</strong> <?= $task['mandays'] ?><br>
-                    <strong>Due:</strong> <?= $task['due_date'] ?><br>
+                    <strong>Mandays:</strong> <?= htmlspecialchars($task['mandays']) ?><br>
+                    <strong>Due:</strong> <?= htmlspecialchars($task['due_date']) ?><br>
                     <strong>Score:</strong> <?= calculateTaskScore($task) ?>
                 </p>
                 <form method="POST" class="d-inline">


### PR DESCRIPTION
## Summary
- ensure mandays and due date are escaped in the task display

## Testing
- `php -l src/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f64620c1c83328739e8b8d4108d96