### PR TITLE
Enhance urgency scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Task priority uses a weighted formula that factors in criticality, effort, due d
 - **Mandays weight**: 15
 - **Urgency max**: 80
 - **Overdue boost**: 100
+- **Due date boosts**:
+  - 1 month left: +5
+  - 1 week left: +10
+  - 3 days left: +20
+  - 1 day left: +30
 
 Urgency uses a reciprocal formula where tasks become more urgent as the due date approaches, and overdue tasks receive a fixed boost:
 
@@ -32,7 +37,17 @@ Urgency uses a reciprocal formula where tasks become more urgent as the due date
 if days_left < 0:
     urgency = OVERDUE_BOOST
 else:
-    urgency = URGENCY_MAX / (1 + days_left)
+    time_boost = 0
+    if days_left <= 1:
+        time_boost = BOOST_1_DAY
+    elif days_left <= 3:
+        time_boost = BOOST_3_DAYS
+    elif days_left <= 7:
+        time_boost = BOOST_1_WEEK
+    elif days_left <= 30:
+        time_boost = BOOST_1_MONTH
+
+    urgency = URGENCY_MAX / (1 + days_left) + time_boost
 
 score = (criticality * CRITICALITY_WEIGHT)
       + (EFFORT_WEIGHT / effort)

--- a/src/index.php
+++ b/src/index.php
@@ -109,14 +109,29 @@ function calculateTaskScore($task) {
     $CRITICALITY_WEIGHT = 50;
     $EFFORT_WEIGHT      = 20;
     $MANDAYS_WEIGHT     = 15;
-    $URGENCY_MAX        = 80;  // Increased from 40
+    $URGENCY_MAX        = 80;  // Base urgency for due dates
     $OVERDUE_BOOST      = 100;
 
-    // Urgency calculation (reciprocal for non-overdue, fixed boost for overdue)
+    // Additional boosts when approaching the due date
+    $BOOST_1_MONTH = 5;   // <= 30 days
+    $BOOST_1_WEEK  = 10;  // <= 7 days
+    $BOOST_3_DAYS  = 20;  // <= 3 days
+    $BOOST_1_DAY   = 30;  // <= 1 day
+
+    // Urgency calculation with stepped boosts as the due date approaches
     if ($daysLeft < 0) {
         $urgencyScore = $OVERDUE_BOOST;
     } else {
-        $urgencyScore = $URGENCY_MAX / (1 + $daysLeft); // DaysLeft=0 gives 80, 1 gives 40, etc.
+        $urgencyScore = $URGENCY_MAX / (1 + $daysLeft);
+        if ($daysLeft <= 1) {
+            $urgencyScore += $BOOST_1_DAY;
+        } elseif ($daysLeft <= 3) {
+            $urgencyScore += $BOOST_3_DAYS;
+        } elseif ($daysLeft <= 7) {
+            $urgencyScore += $BOOST_1_WEEK;
+        } elseif ($daysLeft <= 30) {
+            $urgencyScore += $BOOST_1_MONTH;
+        }
     }
 
     $score  = 0;


### PR DESCRIPTION
## Summary
- introduce stepped time-based boosts in `calculateTaskScore`
- document new boosts in README

## Testing
- `php -l src/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589e35c0148332a32490738f3c277e